### PR TITLE
Fixed Mbed pin init issue

### DIFF
--- a/Suli_Mbed/Suli.cpp
+++ b/Suli_Mbed/Suli.cpp
@@ -12,7 +12,7 @@
  */
 void suli_pin_init(IO_T *pio, PIN_T pin)
 {
-    gpio_init(pio, PIN_INPUT);
+    gpio_init(pio, pin);
 }
 
 


### PR DESCRIPTION
When I imported the Suli Mbed library into the Mbed compiler, the code did not compile. This required a simple fix to the suli_pin_init function.
